### PR TITLE
Insert space to conform to Rubocop requirements

### DIFF
--- a/wikidata_ids_decorator.gemspec
+++ b/wikidata_ids_decorator.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'wikidata_ids_decorator/version'


### PR DESCRIPTION
Rubocop complains unless a space is inserted after the top line in the gem spec (`# coding: utf-8`). As a result, future PRs will fail without this change.