### PR TITLE
[refactor] Extract individual methods

### DIFF
--- a/lib/wikidata_ids_decorator.rb
+++ b/lib/wikidata_ids_decorator.rb
@@ -8,13 +8,13 @@ module WikidataIdsDecorator
     def body
       local_links.each { |a| a[:wikidata] = wdids[a[:title]] }
       remote_links.each { |a| a[:wikidata] = mapped[a[:title]] }
-      doc.to_s
+      working_body.to_s
     end
 
     private
 
-    def doc
-      @doc ||= Nokogiri::HTML(response.body)
+    def working_body
+      @working_body ||= Nokogiri::HTML(response.body)
     end
 
     def wdids
@@ -22,11 +22,11 @@ module WikidataIdsDecorator
     end
 
     def local_links
-      doc.css('#bodyContent a[href*="/wiki"][title]').reject { |a| a[:title].include? ':' }
+      working_body.css('#bodyContent a[href*="/wiki"][title]').reject { |a| a[:title].include? ':' }
     end
 
     def remote_links
-      doc.css('a[href*="wikipedia.org"][title].extiw')
+      working_body.css('a[href*="wikipedia.org"][title].extiw')
     end
 
     def by_lang

--- a/lib/wikidata_ids_decorator.rb
+++ b/lib/wikidata_ids_decorator.rb
@@ -6,8 +6,8 @@ require 'wikidata/fetcher'
 module WikidataIdsDecorator
   class Links < Scraped::Response::Decorator
     def body
-      local_links.each { |a| a[:wikidata] = local_link_ids[a[:title]] }
-      remote_links.each { |a| a[:wikidata] = remote_link_ids[a[:title]] }
+      local_links.each { |llink| llink[:wikidata] = local_link_ids[llink[:title]] }
+      remote_links.each { |rlink| rlink[:wikidata] = remote_link_ids[rlink[:title]] }
       working_body.to_s
     end
 
@@ -18,7 +18,7 @@ module WikidataIdsDecorator
     end
 
     def local_links
-      working_body.css('#bodyContent a[href*="/wiki"][title]').reject { |a| a[:title].include? ':' }
+      working_body.css('#bodyContent a[href*="/wiki"][title]').reject { |link| link[:title].include? ':' }
     end
 
     def local_link_ids
@@ -30,8 +30,8 @@ module WikidataIdsDecorator
     end
 
     def remote_links_by_lang
-      remote_links.select { |a| a[:title].include? ':' }
-                  .map { |a| a[:title].split ':', 2 }
+      remote_links.select { |link| link[:title].include? ':' }
+                  .map { |link| link[:title].split ':', 2 }
                   .group_by(&:first)
                   .map { |lang, arts| [lang, arts.map(&:last)] }
                   .to_h

--- a/lib/wikidata_ids_decorator.rb
+++ b/lib/wikidata_ids_decorator.rb
@@ -6,26 +6,42 @@ require 'wikidata/fetcher'
 module WikidataIdsDecorator
   class Links < Scraped::Response::Decorator
     def body
-      Nokogiri::HTML(super).tap do |doc|
-        local_links = doc.css('#bodyContent a[href*="/wiki"][title]')
-                         .reject { |a| a[:title].include? ':' }
-        wdids = wikidata_ids(local_links.map { |a| a[:title] }.uniq)
-        local_links.each { |a| a[:wikidata] = wdids[a[:title]] }
-
-        remote_links = doc.css('a[href*="wikipedia.org"][title].extiw')
-        by_lang = remote_links.select { |a| a[:title].include? ':' }
-                              .map { |a| a[:title].split ':', 2 }
-                              .group_by(&:first)
-                              .map { |lang, arts| [lang, arts.map(&:last)] }
-                              .to_h
-        mapped = by_lang.flat_map do |lang, names|
-          wikidata_ids(names, lang).map { |page, id| ["#{lang}:#{page}", id] }
-        end.to_h
-        remote_links.each { |a| a[:wikidata] = mapped[a[:title]] }
-      end.to_s
+      local_links.each { |a| a[:wikidata] = wdids[a[:title]] }
+      remote_links.each { |a| a[:wikidata] = mapped[a[:title]] }
+      doc.to_s
     end
 
     private
+
+    def doc
+      @doc ||= Nokogiri::HTML(response.body)
+    end
+
+    def wdids
+      @wdids ||= wikidata_ids(local_links.map { |a| a[:title] }.uniq)
+    end
+
+    def local_links
+      doc.css('#bodyContent a[href*="/wiki"][title]').reject { |a| a[:title].include? ':' }
+    end
+
+    def remote_links
+      doc.css('a[href*="wikipedia.org"][title].extiw')
+    end
+
+    def by_lang
+      remote_links.select { |a| a[:title].include? ':' }
+                  .map { |a| a[:title].split ':', 2 }
+                  .group_by(&:first)
+                  .map { |lang, arts| [lang, arts.map(&:last)] }
+                  .to_h
+    end
+
+    def mapped
+      @mapped ||= by_lang.flat_map do |lang, names|
+        wikidata_ids(names, lang).map { |page, id| ["#{lang}:#{page}", id] }
+      end.to_h
+    end
 
     def wikidata_ids(links, language = default_language)
       WikiData.ids_from_pages(language, links)

--- a/wikidata_ids_decorator.gemspec
+++ b/wikidata_ids_decorator.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-around'
   spec.add_development_dependency 'minitest-vcr'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'reek'
   spec.add_development_dependency 'rubocop', '~> 0.47'
   spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
Rather than doing everything in one big imperative `tap`, split out
individual methods for each part.